### PR TITLE
fix emoji display in invite to participate

### DIFF
--- a/commands/create.js
+++ b/commands/create.js
@@ -118,7 +118,7 @@ exports.run = async (client, message, args) => {
                 giveaway: (client.config.everyoneMention ? "@everyone\n\n" : "")+ client.config.giveawayEmoji + " **GIVEAWAY** " + client.config.giveawayEmoji,
                 giveawayEnded: (client.config.everyoneMention ? "@everyone\n\n" : "")+ client.config.giveawayEmoji + "** GIVEAWAY ENDED **" + client.config.giveawayEmoji,
                 timeRemaining: "Time remaining: **{duration}**!",
-                inviteToParticipate: "React with " + client.config.giveawayEmoji + " to participate!",
+                inviteToParticipate: "React with " + client.config.reaction + " to participate!",
                 winMessage: client.config.giveawayEmoji + " {winners} won **{prize}**!",
                 embedFooter: client.config.botName,
                 noWinner: "Giveaway cancelled, no valid participations.",

--- a/commands/start.js
+++ b/commands/start.js
@@ -54,7 +54,7 @@ exports.run = async (client, message, args) => {
             giveaway: (client.config.everyoneMention ? "@everyone\n\n" : "")+ client.config.giveawayEmoji + "** GIVEAWAY **" + client.config.giveawayEmoji,
             giveawayEnded: (client.config.everyoneMention ? "@everyone\n\n" : "")+ client.config.giveawayEmoji + "** GIVEAWAY ENDED **" + client.config.giveawayEmoji,
             timeRemaining: "Time remaining: **{duration}**!",
-            inviteToParticipate: "React with " + client.config.giveawayEmoji + " to participate!",
+            inviteToParticipate: "React with " + client.config.reaction + " to participate!",
             winMessage: client.config.giveawayEmoji + " {winners} won **{prize}**!",
             embedFooter: client.config.botName,
             noWinner: "Giveaway cancelled, no valid participations.",


### PR DESCRIPTION
Currently, `config.giveawayEmoji` is displayed in the "React with [emoji] to participate!" text. 'config.reaction' should be displayed here instead to avoid confusing giveaway participants.